### PR TITLE
Using transform: translate3d to position masonry items

### DIFF
--- a/Masonry/View.jsx
+++ b/Masonry/View.jsx
@@ -55,7 +55,6 @@
     }
  */
 
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -136,7 +135,7 @@ export default class Masonry extends React.PureComponent {
   }
 
   onResize = throttle(() => {
-    this.layout(((this.state.props || this.props), true);
+    this.layout((this.state.props || this.props), true);
   }, 150, { trailing: true })
 
   dynamicWidth = () => {
@@ -189,7 +188,6 @@ export default class Masonry extends React.PureComponent {
 
     const heightSelector = c.getHeightFromProps;
     const columnSpanSelector = c.getColumnSpanFromProps || defaultColumnSpanSelector;
-
 
     // Decide a starter position for centering
     const viewableWidth = this.node.offsetWidth;
@@ -319,7 +317,6 @@ export default class Masonry extends React.PureComponent {
 
           columnHeights[item.column + index] = Math.max(thisColumn, item.top + item.height + columnGutter);
         });
-
 
       column += columnSpan;
       workingPage.items.push(item);
@@ -477,7 +474,6 @@ export default class Masonry extends React.PureComponent {
     return null;
   }
 
-
   findItemsInSameColumn(itemList, item) {
     return itemList.filter(upperItem => {
       return item.column === upperItem.column ||
@@ -532,7 +528,7 @@ export default class Masonry extends React.PureComponent {
     if (
       (start >= top - extraThreshold && stop <= top + viewableHeight + extraThreshold) || // If page starts and stops within the trigger area
       (start <= top + extraThreshold && stop >= top - extraThreshold) || // If page starts before and runs within trigger area
-      (start >= top - extraThreshold  && start <= top + viewableHeight + extraThreshold) || // If page starts within the trigger area
+      (start >= top - extraThreshold && start <= top + viewableHeight + extraThreshold) || // If page starts within the trigger area
       (stop > top - extraThreshold && stop <= top + viewableHeight + extraThreshold) // If the page stops within the trigger area
     ) {
       return true;
@@ -542,6 +538,7 @@ export default class Masonry extends React.PureComponent {
   }
 
   checkInfiniteLoad(bounds) {
+    if (!this.props.hasMore) { return }
     if (this.props.scrollAnchor === window) {
       if (bounds.top + bounds.height < window.innerHeight + this.props.threshold) {
         this.props.onInfiniteLoad();
@@ -579,7 +576,7 @@ export default class Masonry extends React.PureComponent {
     return this.props.scrollAnchor.offsetHeight;
   }
 
-  onReference = (node) => this.node = node;
+  onReference = (node) => { this.node = node; }
 
   render() {
     const {
@@ -589,7 +586,6 @@ export default class Masonry extends React.PureComponent {
       hasMore,
       loadingElement,
       isLoading,
-      itemProps,
       itemComponent: Item,
     } = this.props;
 

--- a/Masonry/View.jsx
+++ b/Masonry/View.jsx
@@ -110,15 +110,8 @@ export default class Masonry extends React.PureComponent {
 
   state = { averageHeight: 300, pages: [] }
 
-  static getDerivedStateFromProps (nextProps, prevProps) {
-    if (!prevProps.props || nextProps.items.length !== prevProps.props.items.length) {
-      return {props: nextProps}
-    }
-    return {props: null}
-  }
-
   componentDidMount() {
-    this.layout(this.state.props || this.props);
+    this.layout(this.props);
     this.onScroll();
     document.addEventListener('scroll', this.onScroll);
     window.addEventListener('resize', this.onResize);
@@ -136,14 +129,13 @@ export default class Masonry extends React.PureComponent {
   }
 
   onResize = throttle(() => {
-    this.layout((this.state.props || this.props), true);
+    this.layout((this.props), true);
   }, 150, { trailing: true })
 
   dynamicWidth = () => {
-    const _p = this.state.props || this.props;
-    const _cols = _p.numColumns;
+    const _cols = this.props.numColumns;
     const _containerWidth = this.node.offsetWidth;
-    const _gutter = _p.columnGutter;
+    const _gutter = this.props.columnGutter;
     if (this.state.containerWidth === _containerWidth && this.state.columnWidth) {
       return this.state.columnWidth;
     }
@@ -152,7 +144,7 @@ export default class Masonry extends React.PureComponent {
     // number of columns.
     // Number of gutters are one less than number of columns.
     const _dynColWidth = Math.floor((_containerWidth - _gutter * (_cols - 1)) / _cols)
-    const _columnWidth = _cols ? _dynColWidth : _p.columnWidth;
+    const _columnWidth = _cols ? _dynColWidth : this.props.columnWidth;
     if (!_columnWidth) {
       throw new Error(`Can't figure out column width, either 'numColumns' or 'columnWidth' needs to be set.`);
     }

--- a/Masonry/View.jsx
+++ b/Masonry/View.jsx
@@ -1,11 +1,11 @@
 /**
  * Masonry Component for React
  * @author Cole Turner <turner.cole@gmail.com | www.cole.codes>
- * 
+ *
  * If you use this, please retain the author name.
  * Please PR any new features you add so that others can enjoy
  * the blood sweat and tears of open source.
- * 
+ *
  * Features:
  *  - Masonry Layout
  *    A) Items must have fixed column width
@@ -16,8 +16,8 @@
  *    D) New items will layout if the previous layout parameters still apply
  *    E) Function `getState` returns either Redux or local component state
  *  - Infinite Scroll
- * 
- * 
+ *
+ *
  * How to use:
     const myArrayOfItems = [{ name: 'Hello' }, { name: 'World' }]
     <Masonry
@@ -47,7 +47,7 @@
       static getHeightFromProps = (getState, props, columnSpan, columnGutter) => {
         return IMAGE_HEIGHT + TITLE_HEIGHT + FOOTER_HEIGHT;
       }
-      
+
       render() {
         ...
       }
@@ -65,9 +65,9 @@ const defaultColumnSpanSelector = () => 1;
 const sortAscending = (a, b) => a - b;
 const sortTopByAscending = (a, b) => a.top - b.top;
 const classNamePropType = PropTypes.oneOfType([
-    PropTypes.String,
-    PropTypes.array
-  ]).isRequired;
+  PropTypes.string,
+  PropTypes.array
+]).isRequired;
 
 export default class Masonry extends React.PureComponent {
   static propTypes = {
@@ -80,9 +80,9 @@ export default class Masonry extends React.PureComponent {
     hasMore: PropTypes.bool.isRequired,
     isLoading: PropTypes.bool.isRequired,
     items: PropTypes.array.isRequired,
-    itemComponent: PropTypes.oneOf([
+    itemComponent: PropTypes.oneOfType([
       PropTypes.instanceOf(React.Component),
-      PropTypes.function
+      PropTypes.func
     ]).isRequired,
     itemProps: PropTypes.object,
     loadingElement: PropTypes.node,
@@ -498,7 +498,7 @@ export default class Masonry extends React.PureComponent {
     ) {
       return true;
     }
-  
+
     return false;
   }
 

--- a/Masonry/View.jsx
+++ b/Masonry/View.jsx
@@ -155,7 +155,7 @@ export default class Masonry extends React.PureComponent {
     return _columnWidth;
   }
 
-  getItemComponentMethods = (itemComponent) => {
+  prepareComponent = (itemComponent) => {
     let _component = itemComponent.constructor;
     let _componentName = _component.displayName || _component.name;
 
@@ -186,7 +186,7 @@ export default class Masonry extends React.PureComponent {
       itemComponent
     } = props;
 
-    const { componentName, heightSelector, columnSpanSelector } = this.getItemComponentMethods(itemComponent);
+    const { componentName, heightSelector, columnSpanSelector } = this.prepareComponent(itemComponent);
     // Decide a starter position for centering
     const viewableWidth = this.node.offsetWidth;
     const columnWidth = this.dynamicWidth();

--- a/Masonry/View.jsx
+++ b/Masonry/View.jsx
@@ -240,7 +240,7 @@ export default class Masonry extends React.PureComponent {
       }
 
       // Determine the height of this item to stage
-      const height = heightSelector(props.getState, itemProps, columnSpan, columnGutter);
+      const height = heightSelector(props.getState, itemProps, columnSpan, columnGutter, columnWidth);
 
       if (isNaN(height)) {
         console.warn(`Skipping feed item ${componentName} with props ${JSON.stringify(itemProps)} because "${height}" is not a number.`);
@@ -608,7 +608,7 @@ export default class Masonry extends React.PureComponent {
                   return (
                     <Item
                       key={itemIndex}
-                      data-column-span={columnSpan}
+                      columnSpan={columnSpan}
                       style={{
                         position: 'absolute',
                         left: '0',

--- a/Masonry/View.jsx
+++ b/Masonry/View.jsx
@@ -192,10 +192,10 @@ export default class Masonry extends React.PureComponent {
 
     // Decide a starter position for centering
     const viewableWidth = this.node.offsetWidth;
-    const dynamicColumnWidth = this.dynamicWidth()
+    const colWidth = this.dynamicWidth()
     const viewableHeight = this.getViewableHeight();
-    const maxColumns = numColumns || Math.floor(viewableWidth / (dynamicColumnWidth + columnGutter));
-    const spannableWidth = maxColumns * dynamicColumnWidth + (columnGutter * (maxColumns - 1));
+    const maxColumns = numColumns || Math.floor(viewableWidth / (colWidth + columnGutter));
+    const spannableWidth = maxColumns * colWidth + (columnGutter * (maxColumns - 1));
     const viewableStart = this.props.alignCenter && !numColumns ? (viewableWidth - spannableWidth) / 2 : 0;
 
     // Setup bounds and limiters for deciding how to stage items in a page
@@ -254,7 +254,7 @@ export default class Masonry extends React.PureComponent {
         column,
         columnSpan,
         height,
-        width: (columnSpan * dynamicColumnWidth) + ((columnSpan - 1) * columnGutter)
+        width: (columnSpan * colWidth) + ((columnSpan - 1) * columnGutter)
       };
 
       // Here is where the magic happens
@@ -348,7 +348,7 @@ export default class Masonry extends React.PureComponent {
       columnHeights,
       columnGaps,
       maxColumns,
-      dynamicColumnWidth
+      colWidth
     });
   }
 

--- a/Masonry/View.jsx
+++ b/Masonry/View.jsx
@@ -58,7 +58,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import throttle from 'lodash.throttle';
+import throttle from 'lodash/throttle';
 
 const noPage = { stop: 0 };
 const defaultColumnSpanSelector = () => 1;

--- a/Masonry/View.jsx
+++ b/Masonry/View.jsx
@@ -1,6 +1,7 @@
 /**
  * Masonry Component for React
  * @author Cole Turner <turner.cole@gmail.com | www.cole.codes>
+ * @contributors Jan (@jnaO)
  *
  * If you use this, please retain the author name.
  * Please PR any new features you add so that others can enjoy

--- a/Masonry/View.jsx
+++ b/Masonry/View.jsx
@@ -67,7 +67,7 @@ const sortTopByAscending = (a, b) => a.top - b.top;
 const classNamePropType = PropTypes.oneOfType([
   PropTypes.string,
   PropTypes.array
-]).isRequired;
+]);
 
 export default class Masonry extends React.PureComponent {
   static propTypes = {
@@ -104,7 +104,8 @@ export default class Masonry extends React.PureComponent {
       </div>
     ),
     scrollAnchor: window,
-    threshold: window.innerHeight * 2
+    threshold: window.innerHeight * 2,
+    columnGutter: 0
   }
 
   state = { averageHeight: 300, pages: [] }

--- a/Masonry/View.jsx
+++ b/Masonry/View.jsx
@@ -142,14 +142,19 @@ export default class Masonry extends React.PureComponent {
       itemComponent
     } = props;
 
-    const componentName = itemComponent.constructor.displayName || itemComponent.constructor.name;
+    let c = itemComponent.constructor;
+    let componentName = c.displayName || c.name;
+    if (!componentName) {
+      c = itemComponent().type;
+      componentName = c.displayName || c.name;
+    }
 
-    if (!('getHeightFromProps' in itemComponent.constructor)) {
+    if (!('getHeightFromProps' in c)) {
       throw new Error(`Component type ${componentName} does not respond to 'getHeightFromProps'`);
     }
 
-    const heightSelector = itemComponent.constructor.getHeightFromProps;
-    const columnSpanSelector = itemComponent.constructor.getColumnSpanFromProps || defaultColumnSpanSelector;
+    const heightSelector = c.getHeightFromProps;
+    const columnSpanSelector = c.getColumnSpanFromProps || defaultColumnSpanSelector;
 
 
     // Decide a starter position for centering

--- a/Masonry/View.jsx
+++ b/Masonry/View.jsx
@@ -144,10 +144,10 @@ export default class Masonry extends React.PureComponent {
     const _cols = _p.numColumns
     const _containerWidth = this.node.offsetWidth
     const _gutter = _p.columnGutter
-    if (this.state.containerWidth === _containerWidth && this.state._colWidth) {
-      return this.state._colWidth;
+    if (this.state.containerWidth === _containerWidth && this.state.columnWidth) {
+      return this.state.columnWidth;
     }
-    // Column width for will be what ever is left over after the total
+    // Column width will be what ever is left over after the total
     // gutter has been subtracted from the container width, divided by
     // number of columns.
     // Number of gutters are one less than number of columns.

--- a/Masonry/readme.md
+++ b/Masonry/readme.md
@@ -1,5 +1,11 @@
 # Masonry
 
+**Unmaintained warning**
+
+Use at your own risk. This is not an official release and is not supported or maintained. It will get you 99% of the way to what you need if you're looking for a performant masonry layout in React/JS. However, you can expect that it will not work out of the box and will require some tweaks. 
+
+If you would like to volunteer as a maintainer and discuss support in an official open source capacity, please reach out to @coleturner.
+
 ## Useage
 
 This is a two step setup, first you need to create your component that will utilize the Masonry component, and you will also need to supply the Masonry component with a list of data as well as a item component that will receive the data.

--- a/Masonry/readme.md
+++ b/Masonry/readme.md
@@ -1,0 +1,149 @@
+# Masonry
+
+## Useage
+
+This is a two step setup, first you need to create your component that will utilize the Masonry component, and you will also need to supply the Masonry component with a list of data as well as a item component that will receive the data.
+
+As this:
+```jsx
+import React from 'react'
+import Masonry from './path/to/components/Masonry'
+import MyMasonryItem from './path/to/components/MyMasonryItem'
+
+class MyComp extends React.Component {
+  state = {
+    items: null,
+    hasMore: null,
+    isLoading: true,
+  }
+
+  componentDidMount() {
+    this.fetch()
+  }
+
+  fetch () {
+    // update isLoading flag appropriately
+    const additionalData = getMoreData()
+    this.setState((prevState) => ({
+      items: prevState.items.concat(additionalData.items),
+      hasMore: additionalData.hasMore,
+    }))
+  }
+
+  getState = () => this.state
+
+  render () {
+    if (!this.state.items) { return }
+    const myArrayOfItems = [{ name: 'Hello' }, { name: 'World' }]
+    return (<Masonry
+      items={this.state.items}
+      itemComponent={(props) => (<MyMasonryItem />)}
+      alignCenter={true}
+      containerClassName="masonry"
+      layoutClassName="masonry-view"
+      pageClassName="masonry-page"
+      loadingElement={<span>Loading...</span>}
+      columnWidth={columnWidth}
+      numColumns={numColumns}
+      columnGutter={columnGutter}
+      hasMore={this.state.hasMore}
+      isLoading={this.state.isFetching}
+      onInfiniteLoad={this.fetch}
+      getState={this.getState}
+    />)
+  }
+}
+```
+
+And the item:
+```jsx
+class MyMasonryItem extends React.Component {
+  static getColumnSpanFromProps = ({ isFeatured }, getState) => {
+    if (isFeatured) {
+      return 2;
+    }
+    return 1;
+  }
+  static getHeightFromProps = (getState, props, columnSpan, columnGutter) => {
+    return IMAGE_HEIGHT + TITLE_HEIGHT + FOOTER_HEIGHT;
+  }
+
+  render() {
+    ...
+  }
+}
+```
+
+## Options
+```
+items (Array)
+  - Array of data to populate `itemComponent`
+```
+
+```
+itemComponent (React.Component)
+  - Component to be populated with the data in `items`
+```
+
+```
+containerClassName (String | Array)
+  - Optional, css class name(s) for the main container
+```
+
+```
+layoutClassName (String | Array)
+  - Optional, css class name(s) for the `pages` container
+```
+
+```
+pageClassName (String | Array)
+  - Optional, css class name(s) for the `MyMasonryItem`s container
+```
+
+```
+loadingElement (DOM node)
+  - Element to display while loading
+```
+
+```
+numColumns (Integer)
+  - Optional, but one of `columnWidth` and `numColumns` needs to be set,
+    if this is set, column width will be calculated
+```
+
+```
+columnWidth (Integer)
+  - Optional, but one of `columnWidth` and `numColumns` needs to be set,
+    will be ignored if `numColumns` are set
+```
+
+```
+alignCenter (Boolean)
+  - Will have no effect if numColumns is set, else it determin wether to
+    center or left align the content
+```
+
+```
+columnGutter (Integer)
+  - Optional (default: 0), gutter width
+```
+
+```
+hasMore (Boolean)
+  - Flag to indicate if infinite scroll function should be triggered
+```
+
+```
+isLoading (Boolean)
+  - Flag do indicate wether to show the `loadingElement` or not
+```
+
+```
+onInfiniteLoad (Function)
+  - Function to fetch more data, this data
+```
+
+```
+getState (Function)
+  - Function to return state from `MyComp`
+```

--- a/README.md
+++ b/README.md
@@ -4,4 +4,5 @@ Most of these components I wrote in ES6/7 environments.
 
 ## Other
 
-[React Timespan](https://github.com/colepatrickturner/react-timespan)
+* [React Timespan](https://github.com/colepatrickturner/react-timespan)
+* [React Masonry](./Masonry)


### PR DESCRIPTION
So, I've modified this to suit my needs, and here are some of those changes added back. I don't know if you like it, but main new features are:
* Flexible / adaptable width by specifying number of columns
* Position items using `transform: translate3d(x,x,0)` to push rendering onto GPU instead of CPU.

And here's a more in detail list of changes:
* resolved inspecting and picking class functions from `itemComponent` (inspect this one, uncertain of if this is a good way of doing it)
* updated PropTypes
* updated cherrypicking in the `lodash` lib
* option to set number columns, and have it fill the container width with flexible item width
*`componentWillReceiveProps` is deprecated, changed to `getDerivedStateFromProps`, and added layout call on `componentDidUpdate`
* started on readme for Masonry
